### PR TITLE
Rename Way2Web to PAQT (rebranding)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Way2Web Software B.V.
+Copyright (c) 2021 PAQT.com B.V.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Graphite Design System
 
-Library of components for the Graphite Design System
+Library of components for the [Graphite Design System](https://graphitedesignsystem.com).
 
 ### Packages
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 # @graphiteds/core
 
-The Graphite Design System (graphiteds) Core package contains the Web Components that make up the reusable UI building blocks of the Graphite Design System. These components are designed to be used in traditional frontend view libraries/frameworks (such as React, Angular, or Vue), or on their own through traditional JavaScript in the browser.
+The Graphite Design System (graphiteds) Core package contains the Web Components that make up the reusable UI building blocks of the [Graphite Design System](https://graphitedesignsystem.com). These components are designed to be used in traditional frontend view libraries/frameworks (such as React, Angular, or Vue), or on their own through traditional JavaScript in the browser.
 
 ## Browser Support
 
@@ -40,7 +40,7 @@ Then you can use the elements anywhere in your template, JSX, html etc.
 For example:
 
 ```html
-<gr-button href="https://www.way2web.nl">Way2Web</gr-button>
+<gr-button href="https://paqt.com">PAQT</gr-button>
 ```
 
 An example of this setup: https://codesandbox.io/s/graphiteds-script-tag-example-9foz6.
@@ -154,7 +154,7 @@ The components should then be available in any of the Vue components:
 
 ```html
 <template>
-  <gr-button href="https://www.way2web.nl">Way2Web</gr-button>
+  <gr-button href="https://paqt.com">PAQT</gr-button>
 </template>
 ```
 
@@ -261,7 +261,7 @@ The components should then be available in any of the Nuxt pages & components:
 
 ```html
 <template>
-  <gr-button href="https://www.way2web.nl">Way2Web</gr-button>
+  <gr-button href="https://paqt.com">PAQT</gr-button>
 </template>
 ```
 

--- a/packages/core/src/index.html
+++ b/packages/core/src/index.html
@@ -618,7 +618,7 @@
       <section>
         <h3>Link Buttons</h3>
 
-        <gr-button href="https://www.way2web.nl" target="_blank"> Link </gr-button>
+        <gr-button href="https://paqt.com">PAQT</gr-button>
       </section>
 
       <section>

--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -82,5 +82,5 @@ export const config: Config = {
       baseUrl: 'https://example.com/',
     },
   ],
-  preamble: '(C) Way2Web https://www.way2web.nl - MIT License',
+  preamble: '(C) PAQT.com B.V. https://paqt.com - MIT License',
 };

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -43,7 +43,7 @@ import { GrButton } from "@graphiteds/react";
 Use it in your JSX as any React component:
 
 ```html
-<GrButton href="https://www.way2web.nl">Way2Web</GrButton>
+<GrButton href="https://paqt.com">PAQT</GrButton>
 ```
 
 An example of this setup: https://codesandbox.io/s/graphiteds-react-example-yhr9p.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -55,10 +55,10 @@ Use it in your template as any Vue component:
 
 ```jsx
 // In kebab-case
-<gr-button href="https://www.way2web.nl">Way2Web</gr-button>
+<gr-button href="https://paqt.com">PAQT</gr-button>
 
 // Or PascalCase
-<GrButton href="https://www.way2web.nl">Way2Web</GrButton>
+<GrButton href="https://paqt.com">PAQT</GrButton>
 ```
 
 We recommend using kebab-case for our components and PascalCase for your own Vue components to make them visible distinct.


### PR DESCRIPTION
GitHub links can't be renamed yet because our organisation here is still called Way2Web, so this needs to be done later on.